### PR TITLE
hash password verification updated and JWT ready to go

### DIFF
--- a/services/townService/package-lock.json
+++ b/services/townService/package-lock.json
@@ -29,6 +29,7 @@
         "@stryker-mutator/core": "^5.6.1",
         "@stryker-mutator/jest-runner": "^5.6.1",
         "@stryker-mutator/typescript-checker": "^5.6.1",
+        "@types/bcryptjs": "^2.4.2",
         "@types/jest": "^26.0.20",
         "@types/node": "^14.14.13",
         "@typescript-eslint/eslint-plugin": "^4.13.0",
@@ -1480,6 +1481,12 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -12096,6 +12103,12 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==",
+      "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.2",

--- a/services/townService/package.json
+++ b/services/townService/package.json
@@ -28,6 +28,7 @@
     "@stryker-mutator/core": "^5.6.1",
     "@stryker-mutator/jest-runner": "^5.6.1",
     "@stryker-mutator/typescript-checker": "^5.6.1",
+    "@types/bcryptjs": "^2.4.2",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.13",
     "@typescript-eslint/eslint-plugin": "^4.13.0",

--- a/services/townService/src/Utils.ts
+++ b/services/townService/src/Utils.ts
@@ -33,8 +33,8 @@ export async function hashPassword(password: string): Promise<string> {
  * @param userName use for generate JWT token
  * @returns generated JWT token
  */
-export async function signAccessToken(userName: string): Promise<string> {
-  return jwt.sign(userName, process.env.JWT_SECRET);
+export async function signAccessToken(email: string): Promise<string> {
+  return jwt.sign({ userName: email }, process.env.JWT_SECRET);
 }
 
 /**

--- a/services/townService/src/client/SignUpFeature.test.tsx
+++ b/services/townService/src/client/SignUpFeature.test.tsx
@@ -3,7 +3,6 @@ import Express from 'express';
 import http from 'http';
 import { AddressInfo } from 'net';
 import addTownRoutes from '../router/towns';
-import * as utils from '../Utils';
 import TownsServiceClient from './TownsServiceClient';
 import * as prismaFunctions from './prismaFunctions';
 import * as requestHandlers from '../requestHandlers/CoveyTownRequestHandlers';

--- a/services/townService/src/client/prismaFunctions.ts
+++ b/services/townService/src/client/prismaFunctions.ts
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client';
 import prisma from './prismaClient';
 
 export interface CreateUser {

--- a/services/townService/src/requestHandlers/CoveyTownRequestHandlers.ts
+++ b/services/townService/src/requestHandlers/CoveyTownRequestHandlers.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { Socket } from 'socket.io';
+import bcrypt from 'bcryptjs';
 import Player from '../types/Player';
 import { ChatMessage, CoveyTownList, UserLocation } from '../CoveyTypes';
 import CoveyTownListener from '../types/CoveyTownListener';
@@ -370,7 +371,6 @@ export async function authLoginHandler(
     email: requestData.email,
     password: hashedPassword,
   });
-  const bcrypt = require('bcryptjs');
   if (!user || !bcrypt.compareSync(requestData.password, user.hash_password)) {
     return {
       isOK: false,
@@ -381,11 +381,8 @@ export async function authLoginHandler(
       },
     };
   }
-  console.log('hello1')
   const token = await signAccessToken(user.user_name);
-  console.log('hello2')
   if (!token) {
-    console.log('no work')
     return {
       isOK:false,
       response: {
@@ -395,7 +392,6 @@ export async function authLoginHandler(
       },
     };
   }
-  console.log('works')
   return {
     isOK: true,
     response: {

--- a/services/townService/src/requestHandlers/CoveyTownRequestHandlers.ts
+++ b/services/townService/src/requestHandlers/CoveyTownRequestHandlers.ts
@@ -1,16 +1,16 @@
 import assert from 'assert';
-import { Socket } from 'socket.io';
 import bcrypt from 'bcryptjs';
-import Player from '../types/Player';
-import { ChatMessage, CoveyTownList, UserLocation } from '../CoveyTypes';
-import CoveyTownListener from '../types/CoveyTownListener';
-import CoveyTownsStore from '../lib/CoveyTownsStore';
+import { Socket } from 'socket.io';
+import { createUser, findUser } from '../client/prismaFunctions';
 import {
   ConversationAreaCreateRequest,
   ServerConversationArea,
 } from '../client/TownsServiceClient';
-import { hashPassword, verifyAccessToken, signAccessToken } from '../Utils';
-import { createUser, findUser } from '../client/prismaFunctions';
+import { ChatMessage, CoveyTownList, UserLocation } from '../CoveyTypes';
+import CoveyTownsStore from '../lib/CoveyTownsStore';
+import CoveyTownListener from '../types/CoveyTownListener';
+import Player from '../types/Player';
+import { hashPassword, signAccessToken, verifyAccessToken } from '../Utils';
 
 /**
  * The format of a request to join a Town in Covey.Town, as dispatched by the server middleware
@@ -139,6 +139,7 @@ export interface ResponseEnvelope<T> {
 export async function townJoinHandler(
   requestData: TownJoinRequest,
 ): Promise<ResponseEnvelope<TownJoinResponse>> {
+  console.log(verifyAccessToken(requestData.accessToken));
   verifyAccessToken(requestData.accessToken);
   const townsStore = CoveyTownsStore.getInstance();
 
@@ -381,10 +382,10 @@ export async function authLoginHandler(
       },
     };
   }
-  const token = await signAccessToken(user.user_name);
+  const token = await signAccessToken(requestData.email);
   if (!token) {
     return {
-      isOK:false,
+      isOK: false,
       response: {
         username: '',
         message: 'Server error',

--- a/services/townService/src/requestHandlers/CoveyTownRequestHandlers.ts
+++ b/services/townService/src/requestHandlers/CoveyTownRequestHandlers.ts
@@ -370,7 +370,8 @@ export async function authLoginHandler(
     email: requestData.email,
     password: hashedPassword,
   });
-  if (!user || hashedPassword !== user.hash_password) {
+  const bcrypt = require('bcryptjs');
+  if (!user || !bcrypt.compareSync(requestData.password, user.hash_password)) {
     return {
       isOK: false,
       response: {
@@ -380,8 +381,11 @@ export async function authLoginHandler(
       },
     };
   }
+  console.log('hello1')
   const token = await signAccessToken(user.user_name);
+  console.log('hello2')
   if (!token) {
+    console.log('no work')
     return {
       isOK:false,
       response: {
@@ -391,6 +395,7 @@ export async function authLoginHandler(
       },
     };
   }
+  console.log('works')
   return {
     isOK: true,
     response: {

--- a/services/townService/src/router/towns.ts
+++ b/services/townService/src/router/towns.ts
@@ -1,8 +1,10 @@
 import express, { Express } from 'express';
-import io from 'socket.io';
 import { Server } from 'http';
 import { StatusCodes } from 'http-status-codes';
+import io from 'socket.io';
 import {
+  authLoginHandler,
+  authSignupHandler,
   conversationAreaCreateHandler,
   townCreateHandler,
   townDeleteHandler,
@@ -10,8 +12,6 @@ import {
   townListHandler,
   townSubscriptionHandler,
   townUpdateHandler,
-  authSignupHandler,
-  authLoginHandler,
 } from '../requestHandlers/CoveyTownRequestHandlers';
 import { logError } from '../Utils';
 


### PR DESCRIPTION
hashPassword in the backend is now compared with password at frontend using bcrytjs
JWT token is updated so the payload uses email login instead of username. This is necessary because user does not use userName to login but instead their email