### PR TITLE
move types/bcrypt and jsonwebtoken from devdependencies to dependencies

### DIFF
--- a/services/townService/package.json
+++ b/services/townService/package.json
@@ -28,9 +28,7 @@
     "@stryker-mutator/core": "^5.6.1",
     "@stryker-mutator/jest-runner": "^5.6.1",
     "@stryker-mutator/typescript-checker": "^5.6.1",
-    "@types/bcryptjs": "^2.4.2",
     "@types/jest": "^26.0.20",
-    "@types/jsonwebtoken": "^8.5.8",
     "@types/node": "^14.14.13",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "eslint-config-airbnb-typescript": "^12.0.0",
@@ -50,6 +48,8 @@
   "dependencies": {
     "@prisma/client": "^4.2.0",
     "@types/express": "^4.17.9",
+    "@types/bcryptjs": "^2.4.2",
+    "@types/jsonwebtoken": "^8.5.8",
     "axios": "^0.21.1",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",


### PR DESCRIPTION
Heroku is breaking because we are using [import bcrypto from 'bcryptojs'] and the same for jsonwebtoken to avoid using require() since that leads to linter issues. This attemps to fix that problem.