### PR TITLE
Add more test suits for backend

### DIFF
--- a/services/townService/src/Utils.ts
+++ b/services/townService/src/Utils.ts
@@ -44,6 +44,9 @@ export async function signAccessToken(email: string): Promise<string> {
 export async function verifyAccessToken(
   token: string,
 ): Promise<string | jwt.JwtPayload | undefined> {
+  if (token === '') {
+    return undefined;
+  }
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET as string);
     return decoded;

--- a/services/townService/src/client/TownsServiceClient.ts
+++ b/services/townService/src/client/TownsServiceClient.ts
@@ -96,6 +96,7 @@ export interface TownJoinResponse {
 export interface TownCreateRequest {
   friendlyName: string;
   isPubliclyListed: boolean;
+  accessToken?: string;
 }
 
 /**


### PR DESCRIPTION
Additional test suits for creating a town and joining the town with the access token. Moreover, add another constraint for verifyAccessToken function that any empty string will immediately return undefined.